### PR TITLE
Feign multipart download

### DIFF
--- a/feign-form-spring/pom.xml
+++ b/feign-form-spring/pom.xml
@@ -45,6 +45,13 @@ limitations under the License.
     </dependency>
 
     <dependency>
+      <groupId>commons-fileupload</groupId>
+      <artifactId>commons-fileupload</artifactId>
+      <version>1.3.3</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-feign</artifactId>
       <version>1.3.5.RELEASE</version>

--- a/feign-form-spring/src/main/java/feign/form/spring/converter/ByteArrayMultipartFile.java
+++ b/feign-form-spring/src/main/java/feign/form/spring/converter/ByteArrayMultipartFile.java
@@ -1,0 +1,78 @@
+package feign.form.spring.converter;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.util.Assert;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * Straight-forward implementation of interface {@link MultipartFile} where the file
+ * data is held as a byte array in memory.
+ */
+final class ByteArrayMultipartFile implements MultipartFile {
+
+    private final String name;
+    private final String originalFileName;
+    private final String contentType;
+    private final byte[] data;
+
+    ByteArrayMultipartFile(final String name, final String originalFileName,
+                           final String contentType, final byte[] data) {
+        Assert.notNull(data, "Byte array data may not be null!");
+
+        this.name = name;
+        this.originalFileName = originalFileName;
+        this.contentType = contentType;
+        this.data = data;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getOriginalFilename() {
+        return originalFileName;
+    }
+
+    @Override
+    public String getContentType() {
+        return contentType;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return data.length == 0;
+    }
+
+    @Override
+    public long getSize() {
+        return data.length;
+    }
+
+    @Override
+    public byte[] getBytes() {
+        return data;
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return new ByteArrayInputStream(data);
+    }
+
+    @Override
+    public void transferTo(final File destination) throws IOException {
+        final FileOutputStream fos = new FileOutputStream(destination);
+        try {
+            fos.write(data);
+        } finally {
+            fos.close();
+        }
+    }
+
+}

--- a/feign-form-spring/src/main/java/feign/form/spring/converter/IgnoreKeyCaseMap.java
+++ b/feign-form-spring/src/main/java/feign/form/spring/converter/IgnoreKeyCaseMap.java
@@ -1,0 +1,80 @@
+package feign.form.spring.converter;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A Map<String, String> implementation that normalizes the key to UPPER CASE, so
+ * that value retrieval via the key is case insensitive.
+ */
+final class IgnoreKeyCaseMap implements Map<String, String> {
+    private final HashMap<String, String> hashMap = new HashMap<String, String>();
+
+    @Override
+    public int size() {
+        return hashMap.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return hashMap.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(final Object key) {
+        return hashMap.containsKey(normalizeKey(key));
+    }
+
+    @Override
+    public boolean containsValue(final Object value) {
+        return hashMap.containsValue(value);
+    }
+
+    @Override
+    public String get(final Object key) {
+        return hashMap.get(normalizeKey(key));
+    }
+
+    @Override
+    public String put(final String key, final String value) {
+        return hashMap.put(normalizeKey(key), value);
+    }
+
+    @Override
+    public String remove(final Object key) {
+        return hashMap.remove(normalizeKey(key));
+    }
+
+    @Override
+    public void putAll(final Map<? extends String, ? extends String> m) {
+        for (final Map.Entry<? extends String, ? extends String> entry : m.entrySet()) {
+            put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Override
+    public void clear() {
+        hashMap.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return hashMap.keySet();
+    }
+
+    @Override
+    public Collection<String> values() {
+        return hashMap.values();
+    }
+
+    @Override
+    public Set<Entry<String, String>> entrySet() {
+        return hashMap.entrySet();
+    }
+
+    private static String normalizeKey(final Object key) {
+        return key != null ? key.toString().toUpperCase() : null;
+    }
+}

--- a/feign-form-spring/src/main/java/feign/form/spring/converter/SpringManyMultipartFilesReader.java
+++ b/feign-form-spring/src/main/java/feign/form/spring/converter/SpringManyMultipartFilesReader.java
@@ -19,7 +19,6 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
-
 /**
  * Implementation of {@link HttpMessageConverter} that can read multipart/form-data HTTP bodies
  * (writing is not handled because that is already supported by {@link FormHttpMessageConverter}).
@@ -29,7 +28,6 @@ import org.springframework.web.multipart.MultipartFile;
  * multipart body is read into an underlying byte array (in memory) implemented via
  * {@link ByteArrayMultipartFile}.
  */
-
 public class SpringManyMultipartFilesReader extends AbstractHttpMessageConverter<MultipartFile[]> {
 
     private static final Pattern NEWLINES_PATTERN = Pattern.compile("\\R");
@@ -40,6 +38,10 @@ public class SpringManyMultipartFilesReader extends AbstractHttpMessageConverter
 
     private final int bufSize;
 
+    /**
+     * Construct an {@code AbstractHttpMessageConverter} that can read mulitpart/form-data.
+     * @param bufSize The size of the buffer (in bytes) to read the HTTP multipart body.
+     */
     public SpringManyMultipartFilesReader(final int bufSize) {
         super(MediaType.MULTIPART_FORM_DATA);
         this.bufSize = bufSize;

--- a/feign-form-spring/src/main/java/feign/form/spring/converter/SpringManyMultipartFilesReader.java
+++ b/feign-form-spring/src/main/java/feign/form/spring/converter/SpringManyMultipartFilesReader.java
@@ -1,0 +1,137 @@
+package feign.form.spring.converter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.commons.fileupload.MultipartStream;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+
+/**
+ * Implementation of {@link HttpMessageConverter} that can read multipart/form-data HTTP bodies
+ * (writing is not handled because that is already supported by {@link FormHttpMessageConverter}).
+ *
+ * <p>
+ * This reader supports an array of {@link MultipartFile} as the mapping return class type - each
+ * multipart body is read into an underlying byte array (in memory) implemented via
+ * {@link ByteArrayMultipartFile}.
+ */
+
+public class SpringManyMultipartFilesReader extends AbstractHttpMessageConverter<MultipartFile[]> {
+
+    private static final Pattern NEWLINES_PATTERN = Pattern.compile("\\R");
+    private static final Pattern COLON_PATTERN = Pattern.compile(":");
+
+    private static final Pattern SEMICOLON_PATTERN = Pattern.compile(";");
+    private static final Pattern EQUALITY_SIGN_PATTERN = Pattern.compile("=");
+
+    private final int bufSize;
+
+    public SpringManyMultipartFilesReader(final int bufSize) {
+        super(MediaType.MULTIPART_FORM_DATA);
+        this.bufSize = bufSize;
+    }
+
+    @Override
+    protected boolean canWrite(final MediaType mediaType) {
+        return false; // Class NOT meant for writing multipart/form-data HTTP bodies
+    }
+
+    @Override
+    protected boolean supports(final Class<?> clazz) {
+        return MultipartFile[].class == clazz;
+    }
+
+    @Override
+    protected MultipartFile[] readInternal(final Class<? extends MultipartFile[]> clazz,
+                                           final HttpInputMessage inputMessage) throws IOException {
+        final byte[] boundary = getMultiPartBoundary(inputMessage.getHeaders().getContentType());
+        final MultipartStream multipartStream = new MultipartStream(inputMessage.getBody(), boundary, bufSize, null);
+
+        final List<ByteArrayMultipartFile> multiparts = new LinkedList<ByteArrayMultipartFile>();
+        for (boolean nextPart = multipartStream.skipPreamble(); nextPart; nextPart = multipartStream.readBoundary()) {
+            try {
+                multiparts.add(readMultiPart(multipartStream));
+            } catch (final Exception e) {
+                throw new HttpMessageNotReadableException("Multipart body could not be read.", e);
+            }
+        }
+
+        return multiparts.toArray(new ByteArrayMultipartFile[multiparts.size()]);
+    }
+
+    @Override
+    protected void writeInternal(final MultipartFile[] byteArrayMultipartFiles, final HttpOutputMessage outputMessage) {
+        throw new UnsupportedOperationException(getClass().getSimpleName() + " does not support writing to HTTP body.");
+    }
+
+    private byte[] getMultiPartBoundary(final MediaType contentType) {
+        final String boundaryStr = unquote(contentType.getParameter("boundary"));
+        if (!StringUtils.isEmpty(boundaryStr)) {
+            return boundaryStr.getBytes();
+        } else {
+            throw new HttpMessageNotReadableException("Content-Type missing boundary information.");
+        }
+    }
+
+    private ByteArrayMultipartFile readMultiPart(final MultipartStream multipartStream) throws IOException {
+        final IgnoreKeyCaseMap multiPartHeaders = splitIntoKeyValuePairs(multipartStream.readHeaders(),
+                NEWLINES_PATTERN, COLON_PATTERN, false);
+
+        final String multipartContentType = multiPartHeaders.get(HttpHeaders.CONTENT_TYPE);
+        final IgnoreKeyCaseMap contentDisposition = splitIntoKeyValuePairs(
+                multiPartHeaders.get(HttpHeaders.CONTENT_DISPOSITION), SEMICOLON_PATTERN, EQUALITY_SIGN_PATTERN, true);
+
+        if (!contentDisposition.containsKey("form-data")) {
+            throw new HttpMessageNotReadableException("Content-Disposition is not of type form-data.");
+        }
+
+        final ByteArrayOutputStream bodyStream = new ByteArrayOutputStream();
+        multipartStream.readBodyData(bodyStream);
+
+        return new ByteArrayMultipartFile(contentDisposition.get("name"), contentDisposition.get("filename"),
+                multipartContentType, bodyStream.toByteArray());
+    }
+
+    private IgnoreKeyCaseMap splitIntoKeyValuePairs(final String str,
+                                                    final Pattern entriesSeparatorPattern,
+                                                    final Pattern keyValueSeparatorPattern,
+                                                    final boolean unquoteValue) {
+        final IgnoreKeyCaseMap keyValuePairs = new IgnoreKeyCaseMap();
+        if (!StringUtils.isEmpty(str)) {
+            final String[] entries = entriesSeparatorPattern.split(str);
+            for (final String entry : entries) {
+                final String[] pair = keyValueSeparatorPattern.split(entry.trim(), 2);
+                final String key = pair[0].trim();
+                final String value = pair.length > 1 ? pair[1].trim() : "";
+                keyValuePairs.put(key, unquoteValue ? unquote(value) : value);
+            }
+        }
+        return keyValuePairs;
+    }
+
+    private String unquote(final String value) {
+        return value != null
+                ? (isSurroundedBy(value, "\"") || isSurroundedBy(value, "'")
+                        ? value.substring(1, value.length() - 1)
+                        : value)
+                : null;
+    }
+
+    private boolean isSurroundedBy(final String value, final String preSuffix) {
+        return value.length() > 1 && value.startsWith(preSuffix) && value.endsWith(preSuffix);
+    }
+}

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/DownloadClient.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/DownloadClient.java
@@ -1,0 +1,57 @@
+package feign.form.feign.spring;
+
+import feign.codec.Decoder;
+import feign.form.spring.converter.SpringManyMultipartFilesReader;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.web.HttpMessageConverters;
+import org.springframework.cloud.netflix.feign.FeignClient;
+import org.springframework.cloud.netflix.feign.support.SpringDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+@FeignClient(
+        name = "multipart-download-support-service",
+        url = "http://localhost:8080",
+        configuration = DownloadClient.ClientConfiguration.class
+)
+public interface DownloadClient {
+
+    @RequestMapping(
+            value = "/multipart/download/{fileId}",
+            method = GET
+    )
+    MultipartFile[] download(@PathVariable("fileId") String fileId);
+
+    class ClientConfiguration {
+
+        @Autowired
+        private ObjectFactory<HttpMessageConverters> messageConverters;
+
+        @Bean
+        public Decoder feignDecoder () {
+            final List<HttpMessageConverter<?>> springConverters = messageConverters.getObject().getConverters();
+            final List<HttpMessageConverter<?>> decoderConverters
+                    = new ArrayList<HttpMessageConverter<?>>(springConverters.size() + 1);
+
+            decoderConverters.addAll(springConverters);
+            decoderConverters.add(new SpringManyMultipartFilesReader(4096));
+            final HttpMessageConverters httpMessageConverters = new HttpMessageConverters(decoderConverters);
+
+            return new SpringDecoder(new ObjectFactory<HttpMessageConverters>() {
+                @Override
+                public HttpMessageConverters getObject() {
+                    return httpMessageConverters;
+                }
+            });
+        }
+    }
+}

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/Server.java
@@ -16,13 +16,24 @@
 
 package feign.form.feign.spring;
 
+import static org.springframework.http.MediaType.APPLICATION_OCTET_STREAM;
 import static org.springframework.http.MediaType.MULTIPART_FORM_DATA_VALUE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
+import java.nio.charset.Charset;
 import java.util.Map;
+
 import lombok.SneakyThrows;
+import org.apache.commons.codec.CharEncoding;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.netflix.feign.EnableFeignClients;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -87,5 +98,28 @@ public class Server {
                          @RequestParam String userName
   ) {
     return userName + ':' + id + ':' + map.size();
+  }
+
+  @RequestMapping(
+          value = "/multipart/download/{fileId}",
+          method = GET,
+          produces = MULTIPART_FORM_DATA_VALUE
+  )
+  public MultiValueMap<String, Object> download(@PathVariable("fileId") String fileId) {
+    MultiValueMap<String, Object> multiParts = new LinkedMultiValueMap<String, Object>();
+
+    String info = "The text for file ID " + fileId + ". Testing unicode €";
+    HttpHeaders infoPartheader = new HttpHeaders();
+    infoPartheader.setContentType(new MediaType("text", "plain", Charset.forName(CharEncoding.UTF_8)));
+    HttpEntity<String> infoPart = new HttpEntity<String>(info, infoPartheader);
+
+    ClassPathResource file = new ClassPathResource("testfile.txt");
+    HttpHeaders filePartheader = new HttpHeaders();
+    filePartheader.setContentType(APPLICATION_OCTET_STREAM);
+    HttpEntity<ClassPathResource> filePart = new HttpEntity<ClassPathResource>(file, filePartheader);
+
+    multiParts.add("info", infoPart);
+    multiParts.add("file", filePart);
+    return multiParts;
   }
 }

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/SpringMultipartDecoderTest.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/SpringMultipartDecoderTest.java
@@ -27,7 +27,7 @@ public class SpringMultipartDecoderTest {
     private DownloadClient downloadClient;
 
     @Test
-    public void upload1Test () throws Exception {
+    public void downloadTest() throws Exception {
         MultipartFile[] downloads = downloadClient.download("123");
 
         Assert.assertEquals(2, downloads.length);

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/SpringMultipartDecoderTest.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/SpringMultipartDecoderTest.java
@@ -1,0 +1,47 @@
+package feign.form.feign.spring;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.multipart.MultipartFile;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        webEnvironment = DEFINED_PORT,
+        classes = Server.class,
+        properties = {
+                "server.port=8080",
+                "feign.hystrix.enabled=false"
+        }
+)
+public class SpringMultipartDecoderTest {
+
+    @Autowired
+    private DownloadClient downloadClient;
+
+    @Test
+    public void upload1Test () throws Exception {
+        MultipartFile[] downloads = downloadClient.download("123");
+
+        Assert.assertEquals(2, downloads.length);
+
+        Assert.assertEquals("info", downloads[0].getName());
+        MediaType infoContentType = MediaType.parseMediaType(downloads[0].getContentType());
+        Assert.assertTrue(MediaType.TEXT_PLAIN.includes(infoContentType));
+        Assert.assertNotNull(infoContentType.getCharset());
+        Assert.assertEquals("The text for file ID 123. Testing unicode €",
+                IOUtils.toString(downloads[0].getInputStream(), infoContentType.getCharset().name()));
+
+        Assert.assertEquals("testfile.txt", downloads[1].getOriginalFilename());
+        Assert.assertEquals(MediaType.APPLICATION_OCTET_STREAM_VALUE, downloads[1].getContentType());
+        Assert.assertEquals(13, downloads[1].getSize());
+    }
+
+}

--- a/feign-form-spring/src/test/java/feign/form/feign/spring/converter/SpringManyMultipartFilesReaderTest.java
+++ b/feign-form-spring/src/test/java/feign/form/feign/spring/converter/SpringManyMultipartFilesReaderTest.java
@@ -1,0 +1,64 @@
+package feign.form.feign.spring.converter;
+
+import feign.form.spring.converter.SpringManyMultipartFilesReader;
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static java.util.Collections.singletonList;
+
+public class SpringManyMultipartFilesReaderTest {
+
+    private static final String DUMMY_MULTIPART_BOUNDARY = "Boundary_4_574237629_1500021738802";
+
+    @Test
+    public void readMultipartFormDataTest() throws IOException {
+        final SpringManyMultipartFilesReader multipartFilesReader = new SpringManyMultipartFilesReader(4096);
+        final MultipartFile[] multipartFiles = multipartFilesReader.read(MultipartFile[].class, new ValidMulitpartMessage());
+
+        Assert.assertEquals(2, multipartFiles.length);
+
+        Assert.assertEquals(MediaType.APPLICATION_JSON_VALUE, multipartFiles[0].getContentType());
+        Assert.assertEquals("form-item-1", multipartFiles[0].getName());
+        Assert.assertFalse(multipartFiles[0].isEmpty());
+
+        Assert.assertEquals(MediaType.TEXT_PLAIN_VALUE, multipartFiles[1].getContentType());
+        Assert.assertEquals("form-item-2-file-1", multipartFiles[1].getOriginalFilename());
+        Assert.assertEquals("Plain text", IOUtils.toString(multipartFiles[1].getInputStream(), "US-ASCII"));
+    }
+
+    public static class ValidMulitpartMessage implements HttpInputMessage {
+        @Override
+        public InputStream getBody() throws IOException {
+            final String multipartBody = "--" + DUMMY_MULTIPART_BOUNDARY + "\r\n" +
+                    "Content-Type: application/json\r\n" +
+                    "Content-Disposition: form-data; name=\"form-item-1\"\r\n" +
+                    "\r\n" +
+                    "{\"id\":1}" + "\r\n" +
+                    "--" + DUMMY_MULTIPART_BOUNDARY + "\r\n" +
+                    "content-type: text/plain\r\n" +
+                    "content-disposition: Form-Data; Filename=\"form-item-2-file-1\"; Name=\"form-item-2\"\r\n" +
+                    "\r\n" +
+                    "Plain text" + "\r\n" +
+                    "--" + DUMMY_MULTIPART_BOUNDARY + "--\r\n";
+
+            return new ByteArrayInputStream(multipartBody.getBytes("US-ASCII"));
+        }
+
+        @Override
+        public HttpHeaders getHeaders() {
+            final HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.put(HttpHeaders.CONTENT_TYPE,
+                    singletonList(MediaType.MULTIPART_FORM_DATA_VALUE + "; boundary=" + DUMMY_MULTIPART_BOUNDARY));
+            return httpHeaders;
+        }
+    }
+}


### PR DESCRIPTION
Feign in combination with _feign-form_ (and _feign-form-spring_) enables sending of multipart/form-data requests (e.g. for uploads of multiple files). This pull request adds the capability for Feign clients **to receive multipart/form-data responses** (e.g. download of multiple files).

The underlying implementation makes use of Apache _commons-fileupload_ library (version 1.3.3), which handles the parsing of the multipart response. The body data parts are held as byte arrays in memory.

To use this feature, include _SpringManyMultipartFilesReader_ in the list of message converters for the Decoder and have the Feign client return an array of _MultipartFile_:

```
@FeignClient(
        name = "${feign.name}", 
        url = "${feign.url}"
        configuration = DownloadClient.ClientConfiguration.class)
public interface DownloadClient {

    @RequestMapping(
            value = "/multipart/download/{fileId}",
            method = GET)
    MultipartFile[] download(@PathVariable("fileId") String fileId);

    class ClientConfiguration {

        @Autowired
        private ObjectFactory<HttpMessageConverters> messageConverters;

        @Bean
        public Decoder feignDecoder () {
            final List<HttpMessageConverter<?>> converters = Stream.concat(
                    messageConverters.getObject().getConverters().stream(),
                    Stream.of(new SpringManyMultipartFilesReader(4096))
            ).collect(Collectors.toList());

            return new SpringDecoder(() -> new HttpMessageConverters(false, converters));
        }
    }
}
```
  